### PR TITLE
Added tooltip on speaker

### DIFF
--- a/src/Components/Pronunciation/index.jsx
+++ b/src/Components/Pronunciation/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button } from "antd";
+import { Button, Tooltip } from "antd";
 import { SoundOutlined } from "@ant-design/icons";
 import "./Pronunciation.scss";
 
@@ -16,12 +16,19 @@ const Pronunciation = ({ sectionData }) => {
 
   return (
     sectionData.audio.some((audiopath) => audiopath !== "") && (
-      <Button
-        type="text"
-        shape="circle"
-        icon={<SoundOutlined />}
-        onClick={playAudio}
-      />
+      <Tooltip
+        title="Read out"
+        color="#666"
+        placement="left"
+        arrowPointAtCenter
+      >
+        <Button
+          type="text"
+          shape="circle"
+          icon={<SoundOutlined />}
+          onClick={playAudio}
+        />
+      </Tooltip>
     )
   );
 };


### PR DESCRIPTION
Fixed issue #19.

Added a tooltip which is triggered on hovering the speaker.
![Screenshot 2022-08-24 144009](https://user-images.githubusercontent.com/32489433/186379728-eae7d10d-38ae-49b2-a8f4-0619f3a34b41.png)

