### PR TITLE
Solved wordsearch failure issue

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -31,9 +31,9 @@ function App() {
     setSearchResults(response);
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedFetchWordSearchResults = useCallback(
-    () => debounce(fetchAndUpdateSearchResults, 500),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    debounce(fetchAndUpdateSearchResults, 500),
     [searchTerm]
   );
 


### PR DESCRIPTION
Network requests weren't being sent because of the function inside callback. Removed it and added comment to remove exhaustive deps warning to solve the issue.