### PR TITLE
#25 - Centers Search Bar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -6,20 +6,19 @@
 
 body,
 #root {
+  --search-area-height: 32px;
   min-height: 100vh;
 }
-#root {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  position: relative;
-  gap: 20px;
-}
+
 .hidden {
   display: none !important;
 }
+
 .title {
   font-size: 50px;
   font-weight: 800;
-  margin-top: 13rem;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, calc(-100% - var(--search-area-height) / 2 - 20px));
 }

--- a/src/Components/SearchBar/SearchBar.scss
+++ b/src/Components/SearchBar/SearchBar.scss
@@ -1,4 +1,10 @@
 .search-area {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  height: var(--search-area-height);
+
   display: flex;
   flex-direction: column;
   .search-bar {


### PR DESCRIPTION
### Fixes #25.

This PR centers the search bar on the screen and places the Thesaurus text on top of it.

### Screenshots

#### Before:
![image](https://user-images.githubusercontent.com/13608193/187081002-f3ca0b56-3a3c-4446-b504-c58a02bb0090.png)

#### After:
![image](https://user-images.githubusercontent.com/13608193/187081037-a3f8512a-0646-41b7-8a07-7405870b3520.png)

